### PR TITLE
Fix missing spaces in genearated commands

### DIFF
--- a/openapi_server/controllers/jepl.py
+++ b/openapi_server/controllers/jepl.py
@@ -68,7 +68,7 @@ class JePLUtils(object):
         template = env.get_template('commands_script.sh')
         return template.render({
             'checkout_dir': checkout_dir,
-            'commands': '&&'.join(cmd_list)
+            'commands': ' && '.join(cmd_list)
         })
 
     def get_jenkinsfile(config_data_list):


### PR DESCRIPTION
Although this is harmless, the generated commands missed a space around
the "&&" operator.

Fixes #113